### PR TITLE
docs: build versioned quartodoc

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -42,46 +42,6 @@ jobs:
         run: |
           make check
 
-  docs:
-    permissions:
-      contents: write
-    name: "Build Docs"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Upgrade pip
-        run: |
-          python -m pip install --upgrade pip
-      - name: Install dependencies
-        run: |
-          # Install latest quartodoc from GitHub
-          pip install -e ".[dev,test,docs]"
-      - name: Install
-        run: |
-          make install
-
-      - name: Render quarto site
-        run: |
-          make docs-ci
-
-      - name: Publish to GitHub Pages (on push)
-        if: github.event_name == 'push'
-        uses: quarto-dev/quarto-actions/publish@v2
-        with:
-          path: docs
-          render: false
-          target: gh-pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   deploy:
     name: "Deploy to PyPI"
     runs-on: ubuntu-latest

--- a/.github/workflows/quartodoc.yaml
+++ b/.github/workflows/quartodoc.yaml
@@ -17,7 +17,7 @@ jobs:
     name: "Build Docs"
     runs-on: ubuntu-latest
     env:
-      subdir: "_site"
+      subdir: ""
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/quartodoc.yaml
+++ b/.github/workflows/quartodoc.yaml
@@ -59,7 +59,7 @@ jobs:
 
           env_file = os.getenv("GITHUB_ENV")
           with open(env_file, "a") as github_env:
-              github_env.write(subdir)
+              github_env.write(f"subdir={subdir}")
 
       # If event is a tag, set subdir to '<tag_name>'
       - name: "[tag] Set documentation subdir"

--- a/.github/workflows/quartodoc.yaml
+++ b/.github/workflows/quartodoc.yaml
@@ -17,7 +17,7 @@ jobs:
     name: "Build Docs"
     runs-on: ubuntu-latest
     env:
-      subdir: ""
+      DOCS_SUBDIR: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -48,7 +48,7 @@ jobs:
 
       # If event is not a push, inspect shinyswatch version to determine output subdir
       # If dev version --> _site/dev, otherwise build as normal
-      - name: "[push] Set default docs subdir"
+      - name: "[push] Set DOCS_SUBDIR"
         if: github.event_name != 'pull_request'
         shell: python
         run: |
@@ -59,17 +59,17 @@ jobs:
 
           env_file = os.getenv("GITHUB_ENV")
           with open(env_file, "a") as github_env:
-              github_env.write(f"subdir={subdir}")
+              github_env.write(f"DOCS_SUBDIR={subdir}")
 
       # If event is a tag, set subdir to '<tag_name>'
-      - name: "[tag] Set documentation subdir"
+      - name: "[tag] Set versioned DOCS_SUBDIR"
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo "subdir=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "DOCS_SUBDIR=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Render quarto site
         run: |
-          make docs-ci DOCS_SUBDIR=${{ env.subdir }}
+          make docs-ci DOCS_SUBDIR=${{ env.DOCS_SUBDIR }}
 
       - name: Ensure docs/_site is up-to-date before push
         if: github.event_name != 'pull_request'

--- a/.github/workflows/quartodoc.yaml
+++ b/.github/workflows/quartodoc.yaml
@@ -87,11 +87,3 @@ jobs:
           target: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check that README.md is up-to-date
-        run: |
-          make docs-readme
-          if git diff --name-only HEAD | grep -q 'README.md'; then
-            echo '::error file=README.md,title=README is out-of-date::README.md is out of date. Please run `make docs-readme` to update it.'
-            exit 1
-          fi

--- a/.github/workflows/quartodoc.yaml
+++ b/.github/workflows/quartodoc.yaml
@@ -1,0 +1,97 @@
+name: Build quartodoc
+
+on:
+  pull_request:
+  push:
+      tags:
+        - 'v[0-9]+.[0-9]+.[0-9]+'         # build on version tags
+        - '!v[0-9]+.[0-9]+.[0-9]+.[0-9]+' # but not if version involves a dev component
+      branches:
+        - main
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    name: "Build Docs"
+    runs-on: ubuntu-latest
+    env:
+      subdir: "_site"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: docs/_site
+          fetch-depth: 1
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Upgrade pip
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Install dependencies
+        run: |
+          # Install latest quartodoc from GitHub
+          pip install -e ".[dev,test,docs]"
+      - name: Install
+        run: |
+          make install
+
+      # If event is not a push, inspect shinyswatch version to determine output subdir
+      # If dev version --> _site/dev, otherwise build as normal
+      - name: "[push] Set default docs subdir"
+        if: github.event_name != 'pull_request'
+        shell: python
+        run: |
+          import os
+          import shinyswatch
+          is_dev = shinyswatch.__version__.count(".") > 2
+          subdir = "dev" if is_dev else ""
+
+          env_file = os.getenv("GITHUB_ENV")
+          with open(env_file, "a") as github_env:
+              github_env.write(subdir)
+
+      # If event is a tag, set subdir to '<tag_name>'
+      - name: "[tag] Set documentation subdir"
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "subdir=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Render quarto site
+        run: |
+          make docs-ci DOCS_SUBDIR=${{ env.subdir }}
+
+      - name: Ensure docs/_site is up-to-date before push
+        if: github.event_name != 'pull_request'
+        run: |
+          # Force rebase docs/_site
+          cd docs/_site
+          git pull --rebase origin gh-pages
+
+      - name: Publish to GitHub Pages (on tag or push to main)
+        if: github.event_name != 'pull_request'
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          path: docs
+          render: false
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check that README.md is up-to-date
+        run: |
+          make docs-readme
+          if git diff --name-only HEAD | grep -q 'README.md'; then
+            echo '::error file=README.md,title=README is out-of-date::README.md is out of date. Please run `make docs-readme` to update it.'
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ coverage: ## check code coverage quickly with the default Python
 	coverage html
 	$(BROWSER) htmlcov/index.html
 
+# These variables are used by docs-ci (i.e. docs-render-ci) to render the site into
+# a specific subdirectory of _site. This enables us to have multiple documentation
+# sites for the same repository, in particular to put the dev docs at `dev/`.
+DOCS_SUBDIR:=
+DOCS_OUTPUT_DIR:="_site/$(DOCS_SUBDIR)"
+
 quarto-shinylive: ## Make sure quarto-shinylive is installed
 	cd docs && (test -f _extensions/quarto-ext/shinylive/shinylive.lua || quarto install extension --no-prompt quarto-ext/shinylive)
 quarto-interlinks: ## Make sure quartodocs's interlinks is installed
@@ -71,9 +77,11 @@ docs-quartodoc: quarto-shinylive quarto-interlinks ## Build quartodoc
 	cd docs && python -m quartodoc interlinks
 docs-render: quarto-shinylive
 	cd docs && quarto render
+docs-render-ci: quarto-shinylive
+	cd docs && quarto render --no-clean --output-dir $(DOCS_OUTPUT_DIR)
 docs-watch: quarto-shinylive
 	cd docs && quarto preview
-docs-ci: docs-quartodoc docs-render ## Build quartodoc for CI
+docs-ci: docs-quartodoc docs-render-ci ## Build quartodoc for CI
 docs-preview: docs-quartodoc docs-watch ## Build quartodoc for preview
 docs-open:
 	$(BROWSER) docs/_site/index.html


### PR DESCRIPTION
This PR separates the `build-quartodoc` job from the `pytest` workflow.

The goal is to build the quartodoc independently. This workflow now enables building multiple versions of the site:

* On pushes to main we build either to:
    * `dev/` if `shinyswatch.__version__` includes a forth (dev) component
    * `/` otherwise

* On tag pushes, we build into a `v1.2.3/` subfolder.

* In pull requests, we build the docs for testing but do not deploy. In the future, we could build preview docs following the example here https://github.com/rstudio/education-workflows/blob/main/examples/pkgdown.yaml