### PR TITLE
feat: Save and restore theme picker choice in localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * The theme picker now includes Shiny's default theme (as `"shiny"`) and bare Bootstrap (as `"bootstrap"`) as theme options, in addition to the Bootswatch themes. If the initial app theme is a custom `shiny.ui.Theme()`, the custom theme is also included in the theme picker options. (#39)
 
+* The theme picker will now remember the previous theme selection between app uses when the app is re-loaded in the same browser. (#43)
+
 ## [0.6.1] - 2024-04-23
 
 * Include missing theme picker assets in the package. (#36)

--- a/shinyswatch/_theme_picker.py
+++ b/shinyswatch/_theme_picker.py
@@ -127,15 +127,21 @@ def theme_picker_server() -> None:
     @reactive.effect
     @reactive.event(input.__shinyswatch_initial_theme)
     def _():
+        init_theme_name = input.__shinyswatch_initial_theme()["name"]
+        last_theme = input.__shinyswatch_initial_theme()["saved"]
+
         choices = set([*ui.Theme.available_presets(), *bsw5_themes])
         choices = sorted([str(x) for x in choices])
-        if input.__shinyswatch_initial_theme() not in choices:
-            choices = [input.__shinyswatch_initial_theme(), *choices]
+        if init_theme_name and init_theme_name not in choices:
+            choices = [init_theme_name, *choices]
+
+        if last_theme and last_theme not in choices:
+            last_theme = None
 
         ui.update_select(
             "shinyswatch_theme_picker",
             choices=choices,
-            selected=input.__shinyswatch_initial_theme(),
+            selected=last_theme or init_theme_name or "",
         )
 
     @reactive.effect

--- a/shinyswatch/picker/theme_picker.js
+++ b/shinyswatch/picker/theme_picker.js
@@ -48,6 +48,23 @@
   }
 
   /**
+   * Gets the theme from local storage.
+   * @returns {string | null}
+   **/
+  function getThemeLocalStorage () {
+    return localStorage.getItem('shinyswatch-theme')
+  }
+
+  /**
+   * Sets the theme in local storage.
+   * @param {string} theme
+   * @returns {void}
+   **/
+  function setThemeLocalStorage (theme) {
+    localStorage.setItem('shinyswatch-theme', theme)
+  }
+
+  /**
    * Creates a new shinyswatch link element.
    *
    * Note that we don't use `Shiny.renderDependencies()` here because we want to be
@@ -126,6 +143,8 @@
       { once: true }
     )
 
+    setThemeLocalStorage(theme)
+
     if (theme === initialThemeName && getInitialThemeLink()) {
       const newLinks = getInitialThemeLink().map(link => link.cloneNode())
       newLinks[0].onload = () => shinyswatchTransition(true)
@@ -184,12 +203,12 @@
     }
 
     const initLink = getInitialThemeLink()
-    if (!initLink) {
-      window.Shiny.setInputValue('__shinyswatch_initial_theme', '')
-      return
+    const initTheme = {
+      name: initLink ? initialThemeName : '',
+      saved: getThemeLocalStorage() || '',
     }
 
-    window.Shiny.setInputValue('__shinyswatch_initial_theme', initialThemeName)
+    window.Shiny.setInputValue('__shinyswatch_initial_theme', initTheme)
   }
 
   const displayWarning = setTimeout(function () {


### PR DESCRIPTION
Closes #37

We now save the user's last chosen theme in `localStorage` and report this value along with the initial theme name (from the app dev, i.e. the page `theme`) on app startup.

When returning to a shinyswatch app in the same browser, the last chosen theme will be selected. There may be a small flicker on page load that we can't avoid: the app loads with the initial page theme that is then replaced almost immediately by the restored theme selection.

https://github.com/posit-dev/py-shinyswatch/assets/5420529/1012665c-b6ef-489c-abbb-79f41e611414


