### PR TITLE
Fix: Theme picker can be used in dynamic UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,29 @@ shinyswatch.theme.superhero
 Example Shiny application:
 
 <table>
+
 <thead>
+
 <tr>
+
 <th>
+
 File: <code>app.py</code>
 </th>
+
 <th>
+
 Screenshot
 </th>
+
 </tr>
+
 </thead>
+
 <tbody>
+
 <tr>
+
 <td>
 
 ``` python
@@ -80,14 +91,18 @@ app = App(app_ui, server)
 ```
 
 </td>
+
 <td>
 
 ![darkly
 theme](https://raw.githubusercontent.com/rstudio/py-shinyswatch/v0.2.2/readme_darkly.png)
 
 </td>
+
 </tr>
+
 </tbody>
+
 </table>
 
 > Note: When writing [shiny apps that use shinyswatch on

--- a/shinyswatch/__init__.py
+++ b/shinyswatch/__init__.py
@@ -1,6 +1,6 @@
 """Bootswatch + Bootstrap 5 themes for Shiny"""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1-dev0"
 
 from . import theme
 from ._get_theme import get_theme

--- a/shinyswatch/_theme_picker.py
+++ b/shinyswatch/_theme_picker.py
@@ -67,29 +67,32 @@ def theme_picker_ui(default: DEPRECATED_PARAM = DEPRECATED) -> ui.TagChild:
         # Have a div that is hidden by default and is shown if the server does not
         # disable it. This is nice as the warning will be displayed if the server method
         # is not run.
-        ui.div(
+        ui.Tag(
+            "shinyswatch-theme-picker",
             ui.div(
-                ui.HTML("&#9888;<br>"),  # warning triangle
-                "Please include ",
-                ui.code(
-                    "shinyswatch.theme_picker_server()",
-                    style="overflow-wrap: anywhere;",
+                ui.div(
+                    ui.HTML("&#9888;<br>"),  # warning triangle
+                    "Please include ",
+                    ui.code(
+                        "shinyswatch.theme_picker_server()",
+                        style="overflow-wrap: anywhere;",
+                    ),
+                    " in your server function.",
                 ),
-                " in your server function.",
+                style="display: none;",
+                class_="alert alert-danger align-items-center",
+                role="alert",
+                id="shinyswatch_picker_warning",
             ),
-            style="display: none;",
-            class_="alert alert-danger align-items-center",
-            role="alert",
-            id="shinyswatch_picker_warning",
+            ui.input_select(
+                id="shinyswatch_theme_picker",
+                label="Select a theme:",
+                # These choices are filled in by the server logic
+                selected=None,
+                choices=[],
+            ),
+            ui.output_ui("shinyswatch_theme_picker_output"),
         ),
-        ui.input_select(
-            id="shinyswatch_theme_picker",
-            label="Select a theme:",
-            # These choices are filled in by the server logic
-            selected=None,
-            choices=[],
-        ),
-        ui.output_ui("shinyswatch_theme_picker_output"),
         theme_picker_deps(),
     )
 

--- a/shinyswatch/picker/theme_picker.js
+++ b/shinyswatch/picker/theme_picker.js
@@ -1,11 +1,18 @@
-/* globals Shiny,$ */
-(function () {
-  // Stores the default theme links, if not one of the shinyswatch themes
-  // Is always an array, even if there is only one link
-  /** @type {HTMLLinkElement[] | undefined | null} */
-  let initialThemeLink
-  /** @type {string} */
-  let initialThemeName = 'default'
+/* globals Shiny,$,HTMLElement */
+class ShinyswatchThemePicker extends HTMLElement {
+  static hasServerCall = false
+
+  constructor () {
+    super()
+    this.initialThemeLink = undefined
+    this.initialThemeName = 'default'
+    this.setupShinyHandlers()
+  }
+
+  connectedCallback () {
+    this.shinyswatchReportInitialTheme()
+    this.showWarningAfterDelay()
+  }
 
   /**
    * Gets the `<link>` elements of the initial theme.
@@ -15,44 +22,46 @@
    * be a `<link>` element referring to `bootstrap.min.css`.
    * @returns {HTMLLinkElement[] | undefined}
    */
-  function getInitialThemeLink () {
-    if (typeof initialThemeLink !== 'undefined') {
-      return initialThemeLink
+  getInitialThemeLink () {
+    if (typeof this.initialThemeLink !== 'undefined') {
+      return this.initialThemeLink
     }
 
     const initShinyTheme = document.querySelectorAll('link[data-shiny-theme]')
     if (initShinyTheme.length > 0) {
-      initialThemeLink = Array.from(initShinyTheme)
-      const themeNames = initialThemeLink
-        .map(el => el.dataset.shinyTheme)
-        .filter(nm => nm && nm !== '')
+      this.initialThemeLink = Array.from(initShinyTheme)
+      const themeNames = this.initialThemeLink
+        .map((el) => el.dataset.shinyTheme)
+        .filter((nm) => nm && nm !== '')
 
       if (themeNames.length > 0) {
-        initialThemeName = themeNames[0]
+        this.initialThemeName = themeNames[0]
       }
 
-      initialThemeLink.forEach(link => {
-        link.dataset.shinyswatchTheme = initialThemeName
+      this.initialThemeLink.forEach((link) => {
+        link.dataset.shinyswatchTheme = this.initialThemeName
       })
-      return initialThemeLink
+      return this.initialThemeLink
     }
 
-    const initBootstrapLink = document.querySelector('link[href$="bootstrap.min.css"]')
+    const initBootstrapLink = document.querySelector(
+      'link[href$="bootstrap.min.css"]'
+    )
     if (initBootstrapLink) {
       initBootstrapLink.dataset.shinyswatchTheme = 'default'
-      initialThemeLink = [initBootstrapLink]
-      return initialThemeLink
+      this.initialThemeLink = [initBootstrapLink]
+      return this.initialThemeLink
     }
 
-    initialThemeLink = null
+    this.initialThemeLink = null
   }
 
   /**
    * Gets the theme from local storage.
    * @returns {string | null}
    **/
-  function getThemeLocalStorage () {
-    return localStorage.getItem('shinyswatch-theme')
+  getThemeLocalStorage () {
+    return window.localStorage.getItem('shinyswatch-theme')
   }
 
   /**
@@ -60,35 +69,18 @@
    * @param {string} theme
    * @returns {void}
    **/
-  function setThemeLocalStorage (theme) {
-    localStorage.setItem('shinyswatch-theme', theme)
+  setThemeLocalStorage (theme) {
+    window.localStorage.setItem('shinyswatch-theme', theme)
   }
 
-  /**
-   * Creates a new shinyswatch link element.
-   *
-   * Note that we don't use `Shiny.renderDependencies()` here because we want to be
-   * fully in control of how the CSS `<link>` elements are added and removed.
-   *
-   * @param {string} theme The theme name.
-   * @param {Object} dep The JSON-ified HTMLDependency object. We expect a single
-   *   dependency with a single stylesheet and we only create a link from the first
-   *   stylesheet. This assumption holds for `shiny.ui.Theme()` and for
-   *   `shinyswatch.theme.*` themes. Because custom themes may not follow this
-   *   expectation, they are only allowed as the initial theme, which uses a different
-   *   code path.
-   * @returns {HTMLLinkElement}
-   */
-  function makeShinyswatchLink (theme, dep) {
+  makeShinyswatchLink (theme, dep) {
     const link = document.createElement('link')
     link.rel = 'stylesheet'
     link.type = 'text/css'
     for (const [key, value] of Object.entries(dep.stylesheet[0])) {
       link.setAttribute(key, value)
     }
-
     link.dataset.shinyswatchTheme = theme
-
     return link
   }
 
@@ -98,11 +90,8 @@
    *   dependency object.
    * @returns {HTMLLinkElement | HTMLLinkElement[]}
    */
-  function replaceShinyswatchCSS ({ theme, dep }) {
-    const oldLinks = document.querySelectorAll(
-      'link[data-shinyswatch-theme]'
-    )
-
+  replaceShinyswatchCSS ({ theme, dep }) {
+    const oldLinks = document.querySelectorAll('link[data-shinyswatch-theme]')
     // If we have more than one link, all but the last are already scheduled for
     // removal. The current update will only copy and remove the last one.
     const oldLink = oldLinks.length > 0 ? oldLinks[oldLinks.length - 1] : null
@@ -112,20 +101,23 @@
       return
     }
 
-    const removeLinks = oldLink && oldLink.dataset.shinyswatchTheme === initialThemeName
-      ? 'initial'
-      : 'old'
+    const removeLinks =
+      oldLink && oldLink.dataset.shinyswatchTheme === this.initialThemeName
+        ? 'initial'
+        : 'old'
 
     const cleanup = () => {
-      shinyswatchTransition(false)
+      this.shinyswatchTransition(false)
       switch (removeLinks) {
         case 'old':
           oldLink.remove()
           break
         case 'initial':
           document
-            .querySelectorAll(`[data-shinyswatch-theme="${initialThemeName}"]`)
-            .forEach(link => link.remove())
+            .querySelectorAll(
+              `[data-shinyswatch-theme="${this.initialThemeName}"]`
+            )
+            .forEach((link) => link.remove())
           break
       }
     }
@@ -143,16 +135,20 @@
       { once: true }
     )
 
-    setThemeLocalStorage(theme)
+    this.setThemeLocalStorage(theme)
 
-    if (theme === initialThemeName && getInitialThemeLink()) {
-      const newLinks = getInitialThemeLink().map(link => link.cloneNode())
-      newLinks[0].onload = () => shinyswatchTransition(true)
-      newLinks.forEach(nl => oldLink.parentNode.insertBefore(nl, oldLink.nextSibling))
+    if (theme === this.initialThemeName && this.getInitialThemeLink()) {
+      const newLinks = this.getInitialThemeLink().map((link) =>
+        link.cloneNode()
+      )
+      newLinks[0].onload = () => this.shinyswatchTransition(true)
+      newLinks.forEach((nl) =>
+        oldLink.parentNode.insertBefore(nl, oldLink.nextSibling)
+      )
       return newLinks
     } else {
-      const newLink = makeShinyswatchLink(theme, dep)
-      newLink.onload = () => shinyswatchTransition(true)
+      const newLink = this.makeShinyswatchLink(theme, dep)
+      newLink.onload = () => this.shinyswatchTransition(true)
       oldLink.parentNode.insertBefore(newLink, oldLink.nextSibling)
       return newLink
     }
@@ -169,17 +165,15 @@
    *
    * @param {boolean} transitioning
    */
-  function shinyswatchTransition (transitioning) {
+  shinyswatchTransition (transitioning) {
     if (transitioning) {
       document.documentElement.dataset.shinyswatchTransitioning = 'true'
     } else {
-      setTimeout(
-        () => {
-          // Give the transition a tick to end before removing the attribute
-          document.documentElement.removeAttribute('data-shinyswatch-transitioning')
-        },
-        100
-      )
+      setTimeout(() => {
+        document.documentElement.removeAttribute(
+          'data-shinyswatch-transitioning'
+        )
+      }, 100)
     }
   }
 
@@ -193,49 +187,60 @@
    * When detecting the initial theme, if the initial theme is not from shinyswatch, we
    * keep a reference to its link element(s) to use when returning to the theme.
    */
-  function shinyswatchReportInitialTheme () {
+  shinyswatchReportInitialTheme () {
     if (!window.Shiny) {
       return
     }
     if (typeof window.Shiny.setInputValue !== 'function') {
-      setTimeout(shinyswatchReportInitialTheme, 1)
+      setTimeout(() => this.shinyswatchReportInitialTheme(), 1)
       return
     }
 
-    const initLink = getInitialThemeLink()
+    const initLink = this.getInitialThemeLink()
     const initTheme = {
-      name: initLink ? initialThemeName : '',
-      saved: getThemeLocalStorage() || '',
+      name: initLink ? this.initialThemeName : '',
+      saved: this.getThemeLocalStorage() || ''
     }
 
-    window.Shiny.setInputValue('__shinyswatch_initial_theme', initTheme)
+    window.Shiny.setInputValue('__shinyswatch_initial_theme', initTheme, {
+      priority: 'event'
+    })
   }
 
-  function removeWarning() {
-    const warning = document.getElementById("shinyswatch_picker_warning")
+  removeWarning () {
+    const warning = document.getElementById('shinyswatch_picker_warning')
     if (warning) {
       warning.remove()
     }
   }
 
-  function showWarning() {
+  showWarning () {
+    if (ShinyswatchThemePicker.hasServerCall) return
+
     const warning = document.getElementById('shinyswatch_picker_warning')
     if (warning) {
       warning.style.display = null
     }
   }
 
-  if (typeof window.Shiny.setInputValue === "function") {
-    setTimeout(showWarning, 1000)
-  } else {
-    $(window).one("shiny:idle", showWarning)
+  setupShinyHandlers () {
+    Shiny.addCustomMessageHandler('shinyswatch-hide-warning', (_) => {
+      ShinyswatchThemePicker.hasServerCall = true
+      this.removeWarning()
+    })
+
+    Shiny.addCustomMessageHandler('shinyswatch-pick-theme', (message) =>
+      this.replaceShinyswatchCSS(message)
+    )
   }
 
-  Shiny.addCustomMessageHandler('shinyswatch-hide-warning', function (_) {
-    removeWarning()
-  })
+  showWarningAfterDelay () {
+    if (typeof window.Shiny.setInputValue === 'function') {
+      setTimeout(() => this.showWarning(), 1000)
+    } else {
+      $(window).one('shiny:idle', () => this.showWarning())
+    }
+  }
+}
 
-  Shiny.addCustomMessageHandler('shinyswatch-pick-theme', replaceShinyswatchCSS)
-
-  shinyswatchReportInitialTheme()
-})()
+window.customElements.define('shinyswatch-theme-picker', ShinyswatchThemePicker)

--- a/shinyswatch/picker/theme_picker.js
+++ b/shinyswatch/picker/theme_picker.js
@@ -10,8 +10,26 @@ class ShinyswatchThemePicker extends HTMLElement {
   }
 
   connectedCallback () {
+    this.ensureUniqueInstance()
     this.shinyswatchReportInitialTheme()
     this.showWarningAfterDelay()
+  }
+
+  ensureUniqueInstance() {
+    const existingPickers = document.querySelectorAll('[id="shinyswatch_theme_picker"]');
+    if (existingPickers.length > 1) {
+      const message = 'Multiple `shinyswatch.theme_picker_ui()` elements detected. Only one instance per app is supported.'
+      const shinyClientError = new window.CustomEvent('shiny:client-message', {
+        detail: {
+          headline: 'Only one theme picker allowed',
+          message,
+        },
+        bubbles: true,
+        cancelable: true
+      })
+      this.dispatchEvent(shinyClientError)
+      console.error(`[shinyswatch] ${message}`)
+    }
   }
 
   /**


### PR DESCRIPTION
Puts the theme picking in a Custom Element wrapper so that we can ensure initial lifecycle hooks always run regardless of how the theme picker is added to the page.

Fixes #50